### PR TITLE
Hardcover integration: search, upload, UI/Help, local dedupe, responsive toolbar

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -18,6 +18,25 @@
   "error": "Error!",
   "error_message_notion": "An error occurred while sending highlights to Notion. Please check your Page ID and API Key.",
   "help": "Help",
+  "help_hardcover": {
+    "titles": {
+      "1": "1. Get Your Hardcover API Key",
+      "2": "2. Search and Select the Book",
+      "3": "3. Upload Quotes",
+      "4": "4. Security",
+      "5": "5. Avoiding Duplicates"
+    },
+    "steps": {
+      "1": "Open your API settings on <a>Hardcover</a> and copy your API key.",
+      "2": "Paste your key into the dialog (with or without ‘Bearer’ works).",
+      "3": "Enter the book title and author, then click Search. Pick the correct result (cover, author, title, slug).",
+      "4": "Click Submit to upload the current book’s highlights or enable ‘Send all books’ to upload everything.",
+      "5": "If search or upload fails due to network rules, the app automatically retries via a secure proxy.",
+      "6": "To minimize duplicates on Hardcover, consider uploading after you finish a book so each highlight is sent once."
+    },
+    "security": "Your API key is saved only in your browser’s local storage and used from the client. It is never logged, and the app strips an optional ‘Bearer’ prefix automatically.",
+    "dupe_note": "Tip: Upload after finishing a book to avoid duplicates. The app prevents re-sending from this browser, but Hardcover may still contain older entries."
+  },
   "help_page": {
     "titles": {
       "1": "1. Create a Notion Integration",

--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -18,6 +18,25 @@
   "error": "Hata!",
   "error_message_notion": "Alıntılar Notion'a gönderilirken bir hata oluştu. Lütfen Page ID ve API Key değerlerinin doğru olduğunu kontrol edin.",
   "help": "Yardım",
+  "help_hardcover": {
+    "titles": {
+      "1": "1. Hardcover API Anahtarını Alın",
+      "2": "2. Kitabı Arayın ve Seçin",
+      "3": "3. Alıntıları Yükleyin",
+      "4": "4. Güvenlik",
+      "5": "5. Çift Kayıtları Önleme"
+    },
+    "steps": {
+      "1": "API ayarlarını <a>Hardcover</a> üzerinde açın ve anahtarınızı kopyalayın.",
+      "2": "Anahtarı diyaloga yapıştırın (‘Bearer’ ile veya olmadan çalışır).",
+      "3": "Kitap başlığı ve yazarı girip Ara’ya tıklayın. Doğru sonucu (kapak, yazar, başlık, slug) seçin.",
+      "4": "Geçerli kitabın alıntılarını yüklemek için Gönder’e tıklayın ya da ‘Tüm kitapları gönder’ seçeneğini açın.",
+      "5": "Arama veya yükleme ağ kuralları nedeniyle başarısız olursa uygulama otomatik olarak güvenli proxy ile tekrar dener.",
+      "6": "Hardcover’da çift kayıtları en aza indirmek için, her alıntıyı bir kez göndermek adına kitabı bitirdikten sonra yüklemeyi düşünün."
+    },
+    "security": "API anahtarınız yalnızca tarayıcınızın yerel depolamasında saklanır ve istemciden kullanılır. Kaydedilmez ve günlüklenmez, ‘Bearer’ öneki otomatik olarak temizlenir.",
+    "dupe_note": "İpucu: Çift kayıtları önlemek için kitabı bitirdikten sonra yükleyin. Uygulama bu tarayıcıdan tekrar göndermeyi engeller, ancak Hardcover’da eski kayıtlar bulunabilir."
+  },
   "help_page": {
     "titles": {
       "1": "1. Notion Entegrasyonu Oluşturma",

--- a/src/app/api/proxy/hardcover/route.js
+++ b/src/app/api/proxy/hardcover/route.js
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request) {
+  try {
+    const { token, query, variables } = await request.json();
+
+    if (!token || !query) {
+      return NextResponse.json(
+        { message: "Missing token or query" },
+        { status: 400 },
+      );
+    }
+
+    const resp = await fetch("https://api.hardcover.app/v1/graphql", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    const data = await resp.json().catch(() => null);
+    if (!resp.ok) {
+      return NextResponse.json(
+        { message: data?.errors?.[0]?.message || resp.statusText },
+        { status: resp.status },
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(
+      { message: error.message || "Unknown error" },
+      { status: 500 },
+    );
+  }
+}
+

--- a/src/app/components/HardcoverDialog.tsx
+++ b/src/app/components/HardcoverDialog.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useToast } from "@/hooks/use-toast";
+import { HardcoverBookChoice, postQuotesToHardcover, searchHardcoverBooks } from "@/utils/hardcoverUtils";
+import { Highlight, Book } from "@/types";
+import { BookOpenCheck, Loader2, SendToBack } from "lucide-react";
+import { useTranslations } from "next-intl";
+import React, { useEffect, useState } from "react";
+
+interface HardcoverDialogProps {
+  selectedBook: { title: string; author: string; highlights: Highlight[] } | null;
+  allBooks: Book[];
+}
+
+const HardcoverDialog: React.FC<HardcoverDialogProps> = ({ selectedBook, allBooks }) => {
+  const t = useTranslations();
+  const { toast } = useToast();
+
+  const [apiKey, setApiKey] = useState("");
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [queryTitle, setQueryTitle] = useState("");
+  const [queryAuthor, setQueryAuthor] = useState("");
+  const [results, setResults] = useState<HardcoverBookChoice[]>([]);
+  const [selected, setSelected] = useState<HardcoverBookChoice | null>(null);
+  const [sendAll, setSendAll] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("hardcoverApiKey");
+    if (stored) setApiKey(stored);
+  }, []);
+
+  useEffect(() => {
+    // Prefill from currently selected book
+    if (selectedBook) {
+      setQueryTitle(selectedBook.title);
+      setQueryAuthor(selectedBook.author);
+    }
+  }, [selectedBook]);
+
+  const performSearch = async () => {
+    if (!apiKey) {
+      toast({ title: t("error"), description: "Missing Hardcover API key" });
+      return;
+    }
+    setLoading(true);
+    try {
+      let found: HardcoverBookChoice[] = [];
+      try {
+        found = await searchHardcoverBooks(queryTitle, queryAuthor, apiKey);
+      } catch {
+        // direct failed: try proxy
+        found = await searchHardcoverBooks(queryTitle, queryAuthor, apiKey, true);
+      }
+      setResults(found);
+      setSelected(found[0] || null);
+      localStorage.setItem("hardcoverApiKey", apiKey);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : "Search failed";
+      toast({ title: t("error"), description: message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!apiKey || (!sendAll && !selected)) return;
+    localStorage.setItem("hardcoverApiKey", apiKey);
+
+    setLoading(true);
+    try {
+      if (sendAll) {
+        for (const b of allBooks) {
+          const matches = await searchHardcoverBooks(b.title, b.author, apiKey);
+          const choice = matches[0];
+          if (choice) {
+            try {
+              await postQuotesToHardcover(apiKey, choice.bookId, b.highlights);
+            } catch {
+              await postQuotesToHardcover(apiKey, choice.bookId, b.highlights, 1, true);
+            }
+          }
+        }
+        toast({ title: t("success"), description: "Uploaded all books to Hardcover" });
+      } else if (selectedBook) {
+        const chosen = selected;
+        if (!chosen) {
+          toast({ title: t("error"), description: "Please select a book result first" });
+          setLoading(false);
+          return;
+        }
+        try {
+          await postQuotesToHardcover(apiKey, chosen.bookId, selectedBook.highlights);
+        } catch {
+          await postQuotesToHardcover(apiKey, chosen.bookId, selectedBook.highlights, 1, true);
+        }
+        toast({ title: t("success"), description: "Uploaded highlights to Hardcover" });
+      }
+      setOpen(false);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : "Upload failed";
+      toast({ title: t("error"), description: message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" className="text-sm">
+          <SendToBack className="mr-2 size-4" />
+          Upload to Hardcover
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Send highlights to Hardcover</DialogTitle>
+          <DialogDescription>
+            Add your Hardcover API key, search for the correct book, and upload quotes.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <Input
+              placeholder="Hardcover API Key"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              className="h-10 text-base"
+            />
+            <div className="text-xs text-muted-foreground">
+              Don’t have one? Get it from
+              {' '}
+              <a
+                href="https://hardcover.app/account/api"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-primary underline underline-offset-4"
+              >
+                hardcover.app/account/api
+              </a>
+              .
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <Input
+              placeholder="Book title"
+              value={queryTitle}
+              onChange={(e) => setQueryTitle(e.target.value)}
+              className="h-10 text-base"
+            />
+            <Input
+              placeholder="Author"
+              value={queryAuthor}
+              onChange={(e) => setQueryAuthor(e.target.value)}
+              className="h-10 text-base"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={performSearch} disabled={loading}>
+              {loading ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+              Search
+            </Button>
+            <label className="ml-auto inline-flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={sendAll} onChange={(e) => setSendAll(e.target.checked)} />
+              Send all books
+            </label>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Tip: To avoid duplicates on Hardcover, consider uploading after you finish a book. This app prevents re-sending from this browser but can’t remove existing entries in Hardcover.
+          </p>
+          <ScrollArea className="max-h-64 border">
+            <div className="divide-y">
+              {results.map((r) => (
+                <button
+                  key={`${r.bookId}`}
+                  className={`flex w-full items-center gap-3 p-2 text-left hover:bg-muted ${selected?.bookId === r.bookId ? "bg-muted" : ""}`}
+                  onClick={() => setSelected(r)}
+                >
+                  {r.coverUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={r.coverUrl} alt="cover" className="h-12 w-8 object-cover" />
+                  ) : (
+                    <div className="h-12 w-8 bg-muted" />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-medium">{r.title}</div>
+                    <div className="truncate text-sm text-muted-foreground">{r.author || ""}</div>
+                    {r.slug ? (
+                      <div className="truncate text-xs text-muted-foreground">{r.slug}</div>
+                    ) : null}
+                  </div>
+                </button>
+              ))}
+              {results.length === 0 && (
+                <div className="p-3 text-sm text-muted-foreground">No results</div>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button onClick={handleSubmit} disabled={loading || !apiKey || (!sendAll && !selected)}>
+            {loading ? <Loader2 className="mr-2 size-4 animate-spin" /> : <BookOpenCheck className="mr-2 size-4" />}
+            Submit
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default HardcoverDialog;
+

--- a/src/app/components/HelpMenu.tsx
+++ b/src/app/components/HelpMenu.tsx
@@ -34,6 +34,9 @@ const HelpMenu: React.FC = () => {
             <TabsTrigger className="w-full" value="notion">
               Notion
             </TabsTrigger>
+            <TabsTrigger className="w-full" value="hardcover">
+              Hardcover
+            </TabsTrigger>
             <TabsTrigger className="w-full" value="about">
               {t("about_page.titles.1")}
             </TabsTrigger>
@@ -106,6 +109,49 @@ const HelpMenu: React.FC = () => {
                 <li>{t("help_page.steps.7")}</li>
                 <li>{t("help_page.steps.8")}</li>
               </ul>
+            </TabsContent>
+            <TabsContent value="hardcover">
+              <h3 className="mt-2 text-lg font-semibold tracking-tight">
+                <strong>{t("help_hardcover.titles.1")}</strong>
+              </h3>
+              <ol className="my-2 ml-6 list-disc [&>li]:mt-2">
+                <li>
+                  {t.rich("help_hardcover.steps.1", {
+                    a: (chunks) => (
+                      <a
+                        className="text-primary font-medium underline underline-offset-4"
+                        href="https://hardcover.app/account/api"
+                        target="_blank"
+                        rel="noreferrer noopener"
+                      >
+                        {chunks}
+                      </a>
+                    ),
+                  })}
+                </li>
+                <li>{t("help_hardcover.steps.2")}</li>
+              </ol>
+              <h3 className="mt-2 text-lg font-semibold tracking-tight">
+                <strong>{t("help_hardcover.titles.2")}</strong>
+              </h3>
+              <ol className="my-2 ml-6 list-disc [&>li]:mt-2">
+                <li>{t("help_hardcover.steps.3")}</li>
+              </ol>
+              <h3 className="mt-2 text-lg font-semibold tracking-tight">
+                <strong>{t("help_hardcover.titles.3")}</strong>
+              </h3>
+              <ol className="my-2 ml-6 list-disc [&>li]:mt-2">
+                <li>{t("help_hardcover.steps.4")}</li>
+                <li>{t("help_hardcover.steps.5")}</li>
+              </ol>
+              <h3 className="mt-2 text-lg font-semibold tracking-tight">
+                <strong>{t("help_hardcover.titles.4")}</strong>
+              </h3>
+              <p className="my-2 ml-6 text-sm text-muted-foreground">{t("help_hardcover.security")}</p>
+              <h3 className="mt-2 text-lg font-semibold tracking-tight">
+                <strong>{t("help_hardcover.titles.5")}</strong>
+              </h3>
+              <p className="my-2 ml-6 text-sm text-muted-foreground">{t("help_hardcover.dupe_note")}</p>
             </TabsContent>
             <TabsContent value="about">
               <p className="mt-2 leading-7">{t("about_page.section.1")}</p>

--- a/src/app/components/HighlightListToolbar.tsx
+++ b/src/app/components/HighlightListToolbar.tsx
@@ -1,5 +1,6 @@
 import HelpMenu from "@/components/HelpMenu";
 import NotionDialog from "@/components/NotionDialog";
+import HardcoverDialog from "@/components/HardcoverDialog";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -84,8 +85,8 @@ const HighlightListToolbar: React.FC<HighlightListToolbarProps> = ({
   };
 
   return (
-    <div className="sticky top-0 z-10 flex flex-row justify-end gap-x-2 bg-gray-600/5 p-2 dark:bg-gray-50/5">
-      <div className="flex gap-2">
+    <div className="sticky top-0 z-10 flex flex-row flex-wrap justify-end gap-2 bg-gray-600/5 p-2 dark:bg-gray-50/5">
+      <div className="flex w-full flex-row flex-wrap justify-end gap-2 md:w-auto md:flex-nowrap">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="outline" className="text-sm">
@@ -118,6 +119,19 @@ const HighlightListToolbar: React.FC<HighlightListToolbarProps> = ({
           </DropdownMenuContent>
         </DropdownMenu>
         <NotionDialog onSubmit={handleNotionSubmit} />
+        <HardcoverDialog
+          selectedBook={
+            selectedBookId
+              ? (() => {
+                  const b = bookListData.find((x) => x.id === selectedBookId);
+                  return b
+                    ? { title: b.title, author: b.author, highlights: b.highlights }
+                    : null;
+                })()
+              : null
+          }
+          allBooks={bookListData}
+        />
         <HelpMenu />
       </div>
     </div>

--- a/src/app/components/ui/input.tsx
+++ b/src/app/components/ui/input.tsx
@@ -13,7 +13,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-auto w-full rounded-md border border-input bg-background overflow-auto file:px-3 file:py-2 file:mr-2 text-sm ring-offset-background file:border-0 file:bg-gray-50/5 file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-auto w-full rounded-md border border-input bg-background px-3 py-2 file:px-3 file:py-2 file:mr-2 text-sm ring-offset-background file:border-0 file:bg-gray-50/5 file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/app/utils/hardcoverUtils.ts
+++ b/src/app/utils/hardcoverUtils.ts
@@ -1,0 +1,280 @@
+"use client";
+import { Highlight } from "@/types";
+
+export type HardcoverBookChoice = {
+  bookId: number;
+  editionId?: number;
+  title: string;
+  author?: string;
+  slug?: string;
+  coverUrl?: string;
+};
+
+const stripBearer = (raw: string): string => raw.trim().replace(/^Bearer\s+/i, "");
+
+const hardcoverRequest = async (
+  token: string,
+  query: string,
+  variables?: Record<string, unknown>,
+) => {
+  const apiKey = stripBearer(token);
+  const resp = await fetch("https://api.hardcover.app/v1/graphql", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await resp.json().catch(() => ({}));
+  if (!resp.ok || json?.errors) {
+    const message =
+      json?.errors?.[0]?.message || json?.message || resp.statusText || "Request failed";
+    throw new Error(message);
+  }
+  return json as { data?: unknown };
+};
+
+const hardcoverProxy = async (
+  token: string,
+  query: string,
+  variables?: Record<string, unknown>,
+) => {
+  const apiKey = stripBearer(token);
+  const resp = await fetch("/api/proxy/hardcover", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token: apiKey, query, variables }),
+  });
+  const json = await resp.json().catch(() => ({}));
+  if (!resp.ok || json?.errors) {
+    const message =
+      json?.errors?.[0]?.message || json?.message || resp.statusText || "Request failed";
+    throw new Error(message);
+  }
+  return json as { data?: unknown };
+};
+
+export const searchHardcoverBooks = async (
+  title: string,
+  author: string,
+  token: string,
+  useProxy = false,
+): Promise<HardcoverBookChoice[]> => {
+  // Prefer search endpoint for better ranking
+  const query = `
+    query Search($q: String!, $per: Int!, $page: Int!) {
+      search(query: $q, query_type: "books", per_page: $per, page: $page, sort: "activities_count:desc") {
+        results
+      }
+    }
+  `;
+  const requester = useProxy ? hardcoverProxy : hardcoverRequest;
+  const { data } = await requester(token, query, {
+    q: `${title} ${author}`.trim(),
+    per: 10,
+    page: 1,
+  });
+
+  const searchContainer = (data as Record<string, unknown>)?.search as
+    | Record<string, unknown>
+    | undefined;
+  const rawResults = searchContainer?.results as unknown;
+  const results: unknown[] = Array.isArray(rawResults)
+    ? (rawResults as unknown[])
+    : typeof rawResults === "string"
+      ? (() => {
+          try {
+            const parsed = JSON.parse(rawResults);
+            return Array.isArray(parsed)
+              ? (parsed as unknown[])
+              : Array.isArray((parsed as Record<string, unknown>)?.hits)
+                ? (((parsed as Record<string, unknown>).hits as unknown[]) || [])
+                : Array.isArray((parsed as Record<string, unknown>)?.items)
+                  ? (((parsed as Record<string, unknown>).items as unknown[]) || [])
+                  : [];
+          } catch {
+            return [];
+          }
+        })()
+      : Array.isArray((rawResults as Record<string, unknown>)?.hits)
+        ? ((((rawResults as Record<string, unknown>).hits as unknown[]) || []))
+        : Array.isArray((rawResults as Record<string, unknown>)?.items)
+          ? ((((rawResults as Record<string, unknown>).items as unknown[]) || []))
+          : [];
+  // results is a blob of objects; extract the key fields if present
+  const mapped: HardcoverBookChoice[] = results
+    .map((r) => {
+      const asRecord = (v: unknown): Record<string, unknown> =>
+        v && typeof v === "object" ? (v as Record<string, unknown>) : {};
+      const getStr = (v: unknown): string | undefined =>
+        typeof v === "string" ? v : undefined;
+
+      const obj = asRecord(r);
+      const doc = (obj.document ? asRecord(obj.document) : obj) as Record<string, unknown>;
+
+      const image = asRecord(doc.image);
+      const cover = asRecord(doc.cover);
+      const coverUrl = getStr(image.url) || getStr(cover.url);
+
+      const authorName =
+        getStr(doc.author_name) || getStr(doc.primary_author) || getStr(asRecord(doc.author).name);
+
+      const idRaw = doc.book_id ?? doc.id;
+      const id = typeof idRaw === "number" ? idRaw : Number(idRaw);
+
+      if (!id || Number.isNaN(id)) return null;
+
+      const title = getStr(doc.title) || "";
+      const slug = getStr(doc.slug);
+
+      const choice: HardcoverBookChoice = {
+        bookId: id,
+        title,
+        author: authorName,
+        slug,
+        coverUrl: coverUrl,
+      };
+      return choice;
+    })
+    .filter((x): x is HardcoverBookChoice => Boolean(x));
+
+  if (mapped.length > 0) return mapped;
+
+  // Fallback to books query with ilike filters on title and author
+  const fallback = `
+    query BooksByTitleAuthor($title: String!, $author: String!) {
+      books(
+        order_by: { users_read_count: desc }
+        where: {
+          _and: [
+            { title: { _ilike: $title } }
+            { contributions: { author: { name: { _ilike: $author } } } }
+          ]
+        }
+        limit: 10
+      ) {
+        id
+        title
+        slug
+        cached_contributors
+        default_physical_edition { id }
+        default_digital_edition { id }
+        image { url }
+      }
+    }
+  `;
+  const fbVars = { title: `%${title}%`, author: `%${author}%` };
+  const fb = await requester(token, fallback, fbVars);
+  const books = ((fb?.data as Record<string, unknown>)?.books || []) as unknown[];
+  return books.map((raw) => {
+    const asRecord = (v: unknown): Record<string, unknown> =>
+      v && typeof v === "object" ? (v as Record<string, unknown>) : {};
+    const getStr = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+
+    const b = asRecord(raw);
+    const phys = asRecord(b.default_physical_edition);
+    const digi = asRecord(b.default_digital_edition);
+    const edIdRaw = phys.id ?? digi.id;
+    const edId = typeof edIdRaw === "number" ? edIdRaw : edIdRaw != null ? Number(edIdRaw) : undefined;
+
+    const contributors = Array.isArray(b.cached_contributors)
+      ? (b.cached_contributors as unknown[])
+      : [];
+    const first = asRecord(contributors[0]);
+    const firstAuthor = getStr(asRecord(first.author).name);
+
+    const img = asRecord(b.image);
+
+    const choice: HardcoverBookChoice = {
+      bookId: Number(b.id),
+      editionId: edId && !Number.isNaN(edId) ? Number(edId) : undefined,
+      title: getStr(b.title) || "",
+      author: firstAuthor,
+      slug: getStr(b.slug),
+      coverUrl: getStr(img.url),
+    };
+    return choice;
+  });
+};
+
+// Normalization helper for deduping quotes
+const normalizeQuote = (text: string): string => {
+  const unified = text.replace(/\r\n?/g, "\n");
+  const lines = unified.split("\n");
+  while (lines.length > 0 && lines[0].trim() === "") lines.shift();
+  while (lines.length > 0 && lines[lines.length - 1].trim() === "") lines.pop();
+  const cleaned: string[] = [];
+  let lastBlank = false;
+  for (const line of lines) {
+    const trimmed = line.replace(/^\s+|\s+$/g, "");
+    const isBlank = trimmed.length === 0;
+    if (isBlank) {
+      if (!lastBlank) cleaned.push("");
+    } else {
+      cleaned.push(trimmed);
+    }
+    lastBlank = isBlank;
+  }
+  return cleaned.join("\n");
+};
+
+
+const getLocalUploadedSet = (bookId: number): Set<string> => {
+  try {
+    const raw = localStorage.getItem(`hardcoverUploaded:${bookId}`);
+    if (!raw) return new Set();
+    const arr = JSON.parse(raw);
+    return new Set(Array.isArray(arr) ? (arr as string[]) : []);
+  } catch {
+    return new Set();
+  }
+};
+
+const saveLocalUploadedSet = (bookId: number, ids: Set<string>) => {
+  try {
+    localStorage.setItem(`hardcoverUploaded:${bookId}`, JSON.stringify(Array.from(ids)));
+  } catch {
+    // ignore
+  }
+};
+
+export const postQuotesToHardcover = async (
+  token: string,
+  hardcoverBookId: number,
+  highlights: Highlight[],
+  privacySettingId: number = 1,
+  useProxy = false,
+) => {
+  // Local-only dedupe: skip highlights already uploaded from this browser
+  const localIds = getLocalUploadedSet(hardcoverBookId);
+
+  for (const hl of highlights) {
+    if (localIds.has(hl.id)) continue;
+
+    const normalized = normalizeQuote(hl.content);
+    const entry = normalized.replaceAll('"""', '\\"\\"\\"');
+    const mutation = `
+      mutation PostQuote($book_id: Int!, $entry: String!, $privacy: Int!) {
+        insert_reading_journal(
+          object: {
+            book_id: $book_id,
+            event: "quote",
+            tags: { spoiler: false, category: "quote", tag: "" },
+            entry: $entry,
+            privacy_setting_id: $privacy
+          }
+        ) { errors }
+      }
+    `;
+    const requester = useProxy ? hardcoverProxy : hardcoverRequest;
+    await requester(token, mutation, {
+      book_id: hardcoverBookId,
+      entry,
+      privacy: privacySettingId,
+    });
+    localIds.add(hl.id);
+  }
+  saveLocalUploadedSet(hardcoverBookId, localIds);
+};
+


### PR DESCRIPTION
Hey Taylan, hope this doesn't step on your toes or anything, but I got the itch tonight to start working on this on my end and I got it working, so I wanted to send it your way for review. 

This PR adds an optional Hardcover integration alongside the existing Notion flow. 
Users can enter their Hardcover API key (with or without “Bearer”), search by book title and author, select the correct result (cover, author, title, slug), and upload highlights as reading journal “quote” entries. The API key is stored only in the browser’s localStorage and never logged or sent anywhere except directly to Hardcover (with an automatic proxy fallback if the direct request is blocked). I built these changes with GPT-5 in Cursor.
To reduce duplicates, the app performs local, per-browser deduplication using each highlight’s id. I also added a small note recommending uploading after finishing a book to minimize duplicates in Hardcover. The Help dialog now has a “Hardcover” tab with brief setup and usage instructions, a link to the API key page, and the duplicate-avoidance tip.
UI includes a helper link to the Hardcover API page, and some polish on the toolbar to make it responsive to screen size and wraps actions so buttons do not go off the page. Existing functionality, like downloads and Notion, remains unchanged.

Screenshots:
<img width="587" height="464" alt="image" src="https://github.com/user-attachments/assets/3cf5b124-b99d-4802-a917-2f675a170393" />
<img width="1034" height="433" alt="image" src="https://github.com/user-attachments/assets/dacf3aa4-6202-49bd-adcc-7b9b1d5e21e3" />
<img width="529" height="583" alt="image" src="https://github.com/user-attachments/assets/b63964d5-4aa5-45b7-96f6-482e1b7cfda6" />
